### PR TITLE
Play next with source select and play button behavior setting

### DIFF
--- a/omega/plugin.video.umbrella/resources/language/Dutch/strings.po
+++ b/omega/plugin.video.umbrella/resources/language/Dutch/strings.po
@@ -5241,3 +5241,15 @@ msgstr ""
 msgctxt "#40525"
 msgid "Umbrella Addon Settings"
 msgstr ""
+
+msgctxt "#40530"
+msgid "Play button behavior"
+msgstr ""
+
+msgctxt "#40531"
+msgid "Play immediately"
+msgstr ""
+
+msgctxt "#40532"
+msgid "Background scrape"
+msgstr ""

--- a/omega/plugin.video.umbrella/resources/language/English/strings.po
+++ b/omega/plugin.video.umbrella/resources/language/English/strings.po
@@ -5062,3 +5062,15 @@ msgstr ""
 msgctxt "#40529"
 msgid "TorBox"
 msgstr ""
+
+msgctxt "#40530"
+msgid "Play button behavior"
+msgstr ""
+
+msgctxt "#40531"
+msgid "Play immediately"
+msgstr ""
+
+msgctxt "#40532"
+msgid "Background scrape"
+msgstr ""

--- a/omega/plugin.video.umbrella/resources/language/German/strings.po
+++ b/omega/plugin.video.umbrella/resources/language/German/strings.po
@@ -6139,3 +6139,15 @@ msgstr ""
 msgctxt "#40525"
 msgid "Umbrella Addon Settings"
 msgstr ""
+
+msgctxt "#40530"
+msgid "Play button behavior"
+msgstr ""
+
+msgctxt "#40531"
+msgid "Play immediately"
+msgstr ""
+
+msgctxt "#40532"
+msgid "Background scrape"
+msgstr ""

--- a/omega/plugin.video.umbrella/resources/language/Hungarian/strings.po
+++ b/omega/plugin.video.umbrella/resources/language/Hungarian/strings.po
@@ -5237,3 +5237,15 @@ msgstr ""
 msgctxt "#40525"
 msgid "Umbrella Addon Settings"
 msgstr ""
+
+msgctxt "#40530"
+msgid "Play button behavior"
+msgstr ""
+
+msgctxt "#40531"
+msgid "Play immediately"
+msgstr ""
+
+msgctxt "#40532"
+msgid "Background scrape"
+msgstr ""

--- a/omega/plugin.video.umbrella/resources/language/Polish/strings.po
+++ b/omega/plugin.video.umbrella/resources/language/Polish/strings.po
@@ -6351,3 +6351,15 @@ msgstr ""
 msgctxt "#40525"
 msgid "Umbrella Addon Settings"
 msgstr ""
+
+msgctxt "#40530"
+msgid "Play button behavior"
+msgstr ""
+
+msgctxt "#40531"
+msgid "Play immediately"
+msgstr ""
+
+msgctxt "#40532"
+msgid "Background scrape"
+msgstr ""

--- a/omega/plugin.video.umbrella/resources/lib/windows/playnext.py
+++ b/omega/plugin.video.umbrella/resources/lib/windows/playnext.py
@@ -44,11 +44,17 @@ class PlayNextXML(BaseDialog):
 			self.doClose()
 
 	def onClick(self, control_id):
-		if control_id == 3011: # Play Now, skip to end of current
+		if control_id == 3011: # Play Now
 			playerWindow.setProperty('umbrella.playnextPlayPressed', str(1))
 			from resources.lib.modules import log_utils
 			log_utils.log('PlayNext Play Button! Playlist Position: %s Playlist Count: %s ' % (control.playlist.getposition(), control.playlist.size()), log_utils.LOGDEBUG)
-			xbmc.executebuiltin('PlayerControl(BigSkipForward)')
+
+			playNext_behavior = getSetting('playnext.behavior')  # 0 == Play immediately, 1 == Background scrape
+			if playNext_behavior == '0':
+				if getSetting('play.mode.tv') == '0':  # Source select
+					playerWindow.clearProperty('umbrella.preResolved_nextUrl')
+				xbmc.executebuiltin('PlayerControl(Next)')  # This seems more stable than BigStepForward since onPlaybackStopped() is never called
+
 			self.doClose()
 		if control_id == 3012: # Stop playback
 			xbmc.executebuiltin('PlayerControl(Playlist.Clear)')

--- a/omega/plugin.video.umbrella/resources/lib/windows/playnext_stillwatching.py
+++ b/omega/plugin.video.umbrella/resources/lib/windows/playnext_stillwatching.py
@@ -43,8 +43,19 @@ class StillWatchingXML(BaseDialog):
 			self.doClose()
 
 	def onClick(self, control_id):
-		if control_id == 3011: # Play Now, skip to end of current
-			xbmc.executebuiltin('PlayerControl(BigSkipForward)')
+		if control_id == 3011:  # Play Now
+			playerWindow.setProperty('umbrella.playnextPlayPressed', str(1))
+			from resources.lib.modules import log_utils
+			log_utils.log('PlayNext Play Button! Playlist Position: %s Playlist Count: %s ' % (
+			control.playlist.getposition(), control.playlist.size()), log_utils.LOGDEBUG)
+
+			playNext_behavior = getSetting('playnext.behavior')  # 0 == Play immediately, 1 == Background scrape
+			if playNext_behavior == '0':
+				if getSetting('play.mode.tv') == '0':  # Source select
+					playerWindow.clearProperty('umbrella.preResolved_nextUrl')
+				xbmc.executebuiltin(
+					'PlayerControl(Next)')  # This seems more stable than BigStepForward since onPlaybackEnded() is never called
+
 			self.doClose()
 		if control_id == 3012: # Stop playback
 			xbmc.executebuiltin('PlayerControl(Playlist.Clear)')

--- a/omega/plugin.video.umbrella/resources/settings.xml
+++ b/omega/plugin.video.umbrella/resources/settings.xml
@@ -1652,6 +1652,26 @@
 						<heading>40025</heading>
 					</control>
 				</setting>
+
+				<setting id="playnext.behavior" type="integer" label="40530" help="" parent="enable.playnext">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<options>
+							<option label="40531">0</option>
+							<option label="40532">1</option>
+						</options>
+					</constraints>
+					<dependencies>
+						<dependency type="visible">
+							<condition operator="is" setting="enable.playnext">true</condition>
+						</dependency>
+					</dependencies>
+					<control type="list" format="string">
+						<heading>40530</heading>
+					</control>
+				</setting>
+
 				<setting id="showHelpPlayNext" type="action" label="32137" help="">
 					<level>0</level>
 					<data>RunPlugin(plugin://plugin.video.umbrella/?action=tools_ShowHelp&amp;name=playnext)</data>


### PR DESCRIPTION
Hello!

This is an implementation of a new feature - play next with source select. I've always enjoyed the "Play next" dialog, however I've refrained from using it since I like picking my sources way too much. This is a way to have both.

List of the most important changes:
- [Feature] Episodes are no longer hard-coded to auto play when enabling PlayNext (should probably update the help dialog if you decide to merge this PR)
- [Feature] When resolving the next url for PlayNext, the list of all sources is also saved. When source select is enabled and play next is used, the list of sources is retrieved and scraping is skipped, speeding up the process (the sources list appears immediately)
- [Change] I have taken the liberty of splitting the play() function in the Sources() class into three functions for better readability. Feel free to revert this if you don't like it. 
- [Bug fix] When clicking the Play now button on the Play next dialog, PlayerControl(Next) is now used instead of PlayerControl(BigSkipForward). From my testing, this is more stable since onPlaybackStopped() was sometimes being wrongly called and now it isn't.


I have also implemented a new setting - Play button behavior. It has two states:

- Play immediately - play next works as it does now - next source is played as soon as the "Play now" button is pressed
- Background scrape - closes the play next dialog, but keeps the pre-scraped source/s - next source is played when playback ends (when the end of the video is reached or the "Next" button is pressed)

More can probably be done, but I wanted to get this out there so we can discuss. Changes only implemented in the Omega version.