### PR TITLE
Fix: Add title field formatting for unaired episodes

### DIFF
--- a/omega/plugin.video.umbrella/resources/lib/menus/episodes.py
+++ b/omega/plugin.video.umbrella/resources/lib/menus/episodes.py
@@ -879,11 +879,13 @@ class Episodes:
 				except: labelProgress = label
 				isUnaired = False
 				try:
-					if i['unaired'] == 'true': 
-						labelProgress = '[COLOR %s][I]%s[/I][/COLOR]' % (self.unairedcolor, labelProgress)
-						isUnaired = True
+    					if i['unaired'] == 'true': 
+        					labelProgress = '[COLOR %s][I]%s[/I][/COLOR]' % (self.unairedcolor, labelProgress)
+        					i['label'] = labelProgress  # Ensure label is updated
+        					i['title'] = labelProgress  # Match title to label
+        					isUnaired = True
 				except: 
-					isUnaired = False
+    					isUnaired = False
 				if i.get('traktHistory') is True: # uses Trakt lastplayed in utc
 					try:
 						air_datetime = tools.convert_time(stringTime=i.get('lastplayed', ''), zoneFrom='utc', zoneTo='local', formatInput='%Y-%m-%dT%H:%M:%S.000Z', formatOutput='%b %d %Y %I:%M %p', remove_zeroes=True)


### PR DESCRIPTION
This pull request fixes an issue where the add-on only applied color formatting to the label field for unaired episodes. Since some Kodi skins, such as skin.arctic.fuse.2, rely on the title field for rendering views, this update ensures that the same formatting is applied to both label and title.