### PR TITLE
Fix plex and composite source

### DIFF
--- a/omega/plugin.video.umbrella/resources/lib/internal_scrapers/plexshare.py
+++ b/omega/plugin.video.umbrella/resources/lib/internal_scrapers/plexshare.py
@@ -62,7 +62,7 @@ class source:
 			if 'tvshowtitle' in data:
 				title, episode_title = data['tvshowtitle'], data['title']
 				hdlr = 'S%02dE%02d' % (int(data['season']), int(data['episode']))
-				url = '%s%s' % (base_link, episodesearch % (quote(title+' '+episode_title)))
+				url = '%s%s' % (base_link, episodesearch % (quote(episode_title)))
 				years = None
 			else:
 				title, episode_title = data['title'], None
@@ -70,12 +70,15 @@ class source:
 				url = '%s%s' % (base_link, moviesearch % (quote(title), year))
 				years = [str(int(year)-1), str(year), str(int(year)+1)]
 
-			try: results = requests.get(url,timeout=6)
+			try: results = requests.get(url,timeout=60)
 			except requests.exceptions.SSLError: 
 				results = requests.get(url, verify=False)
 
-			if episode_title: results = re.findall(r'(<Video.+?type="episode".+?</Video>)', results.text, flags=re.M | re.S)
-			else: results = re.findall(r'(<Video.+?type="movie".+?</Video>)', results.text, flags=re.M | re.S)
+			if episode_title:
+				results = re.findall(r'(<Video[^>]*type="episode"[^>]*>.*?</Video>)', results.text, flags=re.M | re.S)
+			else:
+				results = re.findall(r'(<Video[^>]*type="movie"[^>]*>.*?</Video>)', results.text, flags=re.M | re.S)
+
 
 		except:
 			source_utils.scraper_error('PLEXSHARE')
@@ -122,7 +125,7 @@ class source:
 
 					if self.composite_installed:
 						key = parseDOM(result, 'Video', ret='key')[0]
-						url = '%s%s?X-Plex-Client-Identifier=%s&X-Plex-Token=%s&mode=5' % (play_link, key, self.client_id, accessToken)
+						url = '%s%s&mode=5' % (play_link, key)
 					else:
 						key = parseDOM(result, 'Part', ret='key')[count].rsplit('/', 1)[0] # remove "/file.mkv" to replace with true file name for dnld
 						url = '%s%s/%s?X-Plex-Client-Identifier=%s&X-Plex-Token=%s' % (play_link, key, file_name, self.client_id, accessToken)

--- a/omega/plugin.video.umbrella/resources/lib/modules/sources.py
+++ b/omega/plugin.video.umbrella/resources/lib/modules/sources.py
@@ -467,7 +467,7 @@ class Sources:
 						control.sleep(200)
 					if not self.url: continue
 					# if not any(x in self.url.lower() for x in video_extensions):
-					if not any(x in self.url.lower() for x in video_extensions) and 'plex.direct:' not in self.url and 'torbox' not in self.url:
+					if not any(x in self.url.lower() for x in video_extensions) and 'plugin://plugin.video.composite_for_plex' not in self.url and 'torbox' not in self.url:
 						log_utils.log('Playback not supported for (playItem()): %s' % self.url, level=log_utils.LOGWARNING)
 						continue
 					if homeWindow.getProperty('umbrella.window_keep_alive') != 'true':
@@ -791,7 +791,7 @@ class Sources:
 							log_utils.log('preResolve failed for : next_sources[i]=%s' % str(next_sources[i]), level=log_utils.LOGWARNING)
 						continue
 					# if not any(x in url.lower() for x in video_extensions):
-					if not any(x in url.lower() for x in video_extensions) and 'plex.direct:' not in url and 'torbox' not in url:
+					if not any(x in url.lower() for x in video_extensions) and 'plugin://plugin.video.composite_for_plex' not in url and 'torbox' not in url:
 						if self.debuglog:
 							log_utils.log('preResolve Playback not supported for (sourcesAutoPlay()): %s' % url, level=log_utils.LOGWARNING)
 						continue
@@ -1272,7 +1272,7 @@ class Sources:
 					if control.monitor.abortRequested(): return sysexit()
 					url = self.sourcesResolve(items[i])
 					# if not any(x in url.lower() for x in video_extensions):
-					if not any(x in url.lower() for x in video_extensions) and 'plex.direct:' not in url and 'torbox' not in url:
+					if not any(x in url.lower() for x in video_extensions) and 'plugin://plugin.video.composite_for_plex' not in url and 'torbox' not in url:
 						log_utils.log('Playback not supported for (sourcesAutoPlay()): %s' % url, level=log_utils.LOGWARNING)
 						continue
 					if url:


### PR DESCRIPTION
- Optimize search functionality to return better results by searching only episode titles in Plex (#422).
- Fix the regular expression in PlexShare to ensure proper filtering (the previous one occasionally show both tv and movie).
- Update url to support composite URLs.
- Replace "plex.direct" URLs with composite URLs, as they lack file extensions.

For composite you need to choose the same library with umbrella and composite (as master library)