### PR TITLE
Fixed incorrect hash compare in torbox module

### DIFF
--- a/matrix/plugin.video.umbrella/resources/lib/debrid/torbox.py
+++ b/matrix/plugin.video.umbrella/resources/lib/debrid/torbox.py
@@ -132,7 +132,7 @@ class TorBox:
 			extensions = supported_video_extensions()
 			extras_filtering_list = tuple(i for i in extras_filter() if not i in title.lower())
 			check = self.check_cache_single(info_hash)
-			match = info_hash in [i['hash'] for i in check['data']]
+			match = info_hash.lower() in [i['hash'].lower() for i in check['data']]
 			if not match: return None
 			torrent = self.add_magnet(magnet_url)
 			if not torrent['success']: return None

--- a/nexus/plugin.video.umbrella/resources/lib/debrid/torbox.py
+++ b/nexus/plugin.video.umbrella/resources/lib/debrid/torbox.py
@@ -132,7 +132,7 @@ class TorBox:
 			extensions = supported_video_extensions()
 			extras_filtering_list = tuple(i for i in extras_filter() if not i in title.lower())
 			check = self.check_cache_single(info_hash)
-			match = info_hash in [i['hash'] for i in check['data']]
+			match = info_hash.lower() in [i['hash'].lower() for i in check['data']]
 			if not match: return None
 			torrent = self.add_magnet(magnet_url)
 			if not torrent['success']: return None

--- a/omega/plugin.video.umbrella/resources/lib/debrid/torbox.py
+++ b/omega/plugin.video.umbrella/resources/lib/debrid/torbox.py
@@ -132,7 +132,7 @@ class TorBox:
 			extensions = supported_video_extensions()
 			extras_filtering_list = tuple(i for i in extras_filter() if not i in title.lower())
 			check = self.check_cache_single(info_hash)
-			match = info_hash in [i['hash'] for i in check['data']]
+			match = info_hash.lower() in [i['hash'].lower() for i in check['data']]
 			if not match: return None
 			torrent = self.add_magnet(magnet_url)
 			if not torrent['success']: return None


### PR DESCRIPTION
One of the hashes is lower case and the other is upper case, so the resolve is failing even though the source is cached. This should fix all of the "No stream available" errors myself and others have been seeing with TorBox specifically.