### PR TITLE
Add option to prioritize a specific language to the top of results

### DIFF
--- a/piers/plugin.video.umbrella/resources/language/English/strings.po
+++ b/piers/plugin.video.umbrella/resources/language/English/strings.po
@@ -5751,3 +5751,11 @@ msgstr ""
 msgctxt "#40704"
 msgid "Prefer Smaller File Sizes"
 msgstr ""
+
+msgctxt "#40705"
+msgid "Prioritize Language to top"
+msgstr ""
+
+msgctxt "#40706"
+msgid "Priority Language"
+msgstr ""

--- a/piers/plugin.video.umbrella/resources/lib/modules/sources.py
+++ b/piers/plugin.video.umbrella/resources/lib/modules/sources.py
@@ -1311,8 +1311,66 @@ class Sources:
 		self.sources = filter
 
 		self.sources = self.sources[:4000]
+		
+		if len(self.sources) > 0:
+			self.sources = self.sort_language_to_top(self.sources)
+
 		control.hide()
 		return self.sources
+
+	def sort_language_to_top(self, results):
+		import re
+		from xbmc import convertLanguage as cl, ISO_639_1, ISO_639_2
+		try:
+			# Check if the language filter toggle is enabled in settings.xml
+			is_language_filter_enabled = control.setting('results.language_filter') == 'true'
+			if is_language_filter_enabled:
+				# Read the configured priority language using the correct XML setting ID
+				priority_language = control.setting('results.language') or 'English'
+			else:
+				priority_language = 'None'
+				
+			# If the filter is disabled or set to None, return original results immediately
+			if priority_language == 'None':
+				return results
+				
+			# Dynamically generate standard ISO codes via Kodi for the selected language
+			language_tags = [priority_language, cl(priority_language, ISO_639_2), cl(priority_language, ISO_639_1)]
+			
+			# Clean the list to remove any None values or empty strings returned by Kodi
+			language_tags = [tag for tag in language_tags if tag]
+			
+			# Define global multi-language tags (common typos/variations included)
+			global_multi_tags = ['multi', 'multilang', 'multilanguage', 'mutli']
+			
+			# Create two distinct regex patterns to establish the 3-tier hierarchy
+			lang_pattern = r'\b(%s)\b' % '|'.join(language_tags)
+			multi_pattern = r'\b(%s)\b' % '|'.join(global_multi_tags)
+			
+			# Initialize 3 separate container lists for sorting priority
+			tier_1_lang = []   # Tier 1: Explicit language ISO codes found (e.g., "ENG" or "ENG MULTI")
+			tier_2_multi = []  # Tier 2: No specific language ISO, but contains a generic MULTI tag (e.g., "MULTI")
+			tier_3_other = []  # Tier 3: Everything else (e.g., pure English or other unsupported languages)
+			
+			# Loop through the scraped sources
+			for i in results:
+				name = i.get('name', '')
+				if re.search(lang_pattern, name, re.I):
+					# Matches specific language tag: pushed to absolute top (Tier 1)
+					tier_1_lang.append(i)
+				elif re.search(multi_pattern, name, re.I):
+					# Matches generic multi tag without explicit local language tag: goes to Tier 2
+					tier_2_multi.append(i)
+				else:
+					# No language or multi match: dropped to the bottom (Tier 3)
+					tier_3_other.append(i)
+			
+			# Merge all tiers back into a single list maintaining the strict hierarchy: Tier 1 > Tier 2 > Tier 3
+			results = tier_1_lang + tier_2_multi + tier_3_other
+		except:
+			import traceback
+			log_utils.log('Language Priority Error: %s' % traceback.format_exc(), level=log_utils.LOGDEBUG)
+		return results
 
 	def filter_dupes(self):
 		filter = []

--- a/piers/plugin.video.umbrella/resources/settings.xml
+++ b/piers/plugin.video.umbrella/resources/settings.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" ?>
+<?xml version="1.0" ?>
 <settings version="1">
 	<section id="plugin.video.umbrella">
 		<category id="general" label="32310" help="40183">
@@ -1691,6 +1691,68 @@
 					<level>0</level>
 					<default>false</default>
 					<control type="toggle"/>
+				</setting>
+				<setting id="results.language_filter" type="boolean" label="40705">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
+				<setting id="results.language" type="string" label="40706" parent="results.language_filter">
+					<level>0</level>
+					<default>English</default>
+					<constraints>
+						<options>
+							<option>English</option>
+							<option>Arabic</option>
+							<option>Bulgarian</option>
+							<option>Chinese</option>
+							<option>Croatian</option>
+							<option>Czech</option>
+							<option>Danish</option>
+							<option>Dutch</option>
+							<option>Estonian</option>
+							<option>Finnish</option>
+							<option>French</option>
+							<option>German</option>
+							<option>Greek</option>
+							<option>Hebrew</option>
+							<option>Hindi</option>
+							<option>Hungarian</option>
+							<option>Indonesian</option>
+							<option>Italian</option>
+							<option>Japanese</option>
+							<option>Korean</option>
+							<option>Latvian</option>
+							<option>Lithuanian</option>
+							<option>Malay</option>
+							<option>Norwegian</option>
+							<option>Persian</option>
+							<option>Polish</option>
+							<option>Portuguese</option>
+							<option>Romanian</option>
+							<option>Russian</option>
+							<option>Serbian</option>
+							<option>Slovakian</option>
+							<option>Slovenian</option>
+							<option>Spanish</option>
+							<option>Swedish</option>
+							<option>Taiwanese</option>
+							<option>Tamil</option>
+							<option>Telugu</option>
+							<option>Thai</option>
+							<option>Turkish</option>
+							<option>Ukrainian</option>
+							<option>Vietnamese</option>
+						</options>
+					</constraints>
+					<dependencies>
+						<dependency type="visible">
+							<condition operator="is" setting="results.language_filter">true</condition>
+						</dependency>
+					</dependencies>
+					<control type="list" format="string">
+						<heading>Priority Language</heading>
+					</control>
 				</setting>
 			</group>
 			<group id="2" label="40144">


### PR DESCRIPTION
### Description
This PR introduces a feature that allows users to prioritize a specific language in the scraped results list, porting the logic already implemented in the POV addon. When enabled, streams matching the selected language are grouped and moved to the top of the list.

This is highly beneficial for non-English or multilingual users who want to quickly see streams available in their native language without completely filtering out English results.

### How it works
Instead of destructive filtering, the sorting mechanism takes the already sorted results (which already account for Umbrella's native resolution and codec preferences) and refines the final list into **three distinct tiers** based on regex matching:

1. **Tier 1 (High Priority):** Streams containing an explicit match for the user's selected priority language (e.g., `ENG`, `English`).
2. **Tier 2 (Medium Priority):** Streams tagged with generic multi-language indicators (e.g., `MULTI`, `Multilang`), which likely include the preferred language.
3. **Tier 3 (Standard Priority):** The remaining scraped streams (English-only or other languages).

Finally, these three tiers are concatenated back into a single list. This ensures that the user's native language always appears first, while Umbrella's native sorting (resolution, source, codecs) remains intact *within* each individual tier.

### Changes Included
* **`sources.py`**: Added the three-tier language sorting function at the end of the sorting process. Includes a safe short-circuit to `'None'` if the toggle is disabled to prevent unnecessary processing overhead or potential `NameError` crashes.
* **`settings.xml`**: Added `results.language_filter` (toggle) and `results.language` (string setting) utilizing the parent-child hierarchy.
* **`strings.po`**: Added corresponding localization strings.