### PR TITLE
service: make worker threads daemon + join on abort to fix crash on exit

### DIFF
--- a/matrix/plugin.video.umbrella/service.py
+++ b/matrix/plugin.video.umbrella/service.py
@@ -445,14 +445,14 @@ def main():
 		#SyncMovieLibrary().run()
 		#control.checkPlayNextEpisodes()
 		if control.setting('library.service.update') == 'true':
-			libraryService = Thread(target=LibraryService().run)
+			libraryService = Thread(target=LibraryService().run, daemon=True)
 			libraryService.start()
 		if control.setting('general.checkAddonUpdates') == 'true':
 			AddonCheckUpdate().run()
 		VersionIsUpdateCheck().run()
 		checkAutoStart().run()
 
-		syncServices = Thread(target=SyncServices().run) # run service in case user auth's trakt later, sync will loop and do nothing without valid auth'd account
+		syncServices = Thread(target=SyncServices().run, daemon=True) # run service in case user auth's trakt later, sync will loop and do nothing without valid auth'd account
 		syncServices.start()
 
 		# if getTraktCredentialsInfo():
@@ -469,10 +469,10 @@ def main():
 	SettingsMonitor().waitForAbort()
 	# start monitoring settings changes events
 	control.log('[ plugin.video.umbrella ]  Settings Monitor Service Stopping...', LOGINFO)
-	del syncServices # prob does not kill a running thread
+	if syncServices and syncServices.is_alive(): syncServices.join(2)
 	control.log('[ plugin.video.umbrella ]  Account Sync Service Stopping...', LOGINFO)
 	if libraryService:
-		del libraryService # prob does not kill a running thread
+		if libraryService.is_alive(): libraryService.join(2)
 		control.log('[ plugin.video.umbrella ]  Library Update Service Stopping...', LOGINFO)
 	if schedTrakt:
 		schedTrakt.cancel()


### PR DESCRIPTION
## Problem

Kodi frequently crashes **on exit** (SIGABRT/SIGSEGV) when Umbrella is installed. The Kodi log shows:

```
CPythonInvoker(0, .../plugin.video.umbrella/service.py): script didn't stop in 5 seconds - let's kill it
```

followed by an abort during Python interpreter teardown (`CPythonInvoker::stop` -> `CServiceAddonManager::Stop` -> `CApplication::Stop`).

## Root cause

In `service.py`, `main()` starts the `SyncServices` and `LibraryService` workers as **non-daemon** threads and only `del`s the references on shutdown — it never joins or signals them:

```python
syncServices = Thread(target=SyncServices().run)
...
del syncServices # prob does not kill a running thread
```

At interpreter shutdown CPython's `threading._shutdown()` **joins all non-daemon threads**. The sync loops do poll `abortRequested()`, but their actual work makes blocking network calls (trakt `/sync/last_activities`, simkl, debrid `account_info`, ...) that are not abort-aware. If shutdown lands while one of those requests is in flight on a slow/hung connection, the join hangs, Kodi's 5-second timer expires, and it force-kills the interpreter mid-teardown — corrupting the heap and crashing. Most visible on Linux.

## Fix (one file, `service.py`)

- start both workers as **daemon threads** so interpreter teardown can never block on them
- replace the `del` calls with a brief `join(2)` (well inside Kodi's 5 s grace window) so they still exit cleanly in the normal case

Purely service-lifecycle hardening — no functional change to scraping, sync, or playback.

## Testing

Tested on CachyOS (Kodi 21.3 "Omega", Python 3.12). Before: Kodi crashed on essentially every exit with the signature above (confirmed in core dumps — abort in `CPythonInvoker::stop`). After: clean shutdown, no core dumps, no `kodi_crashlog-*.log` generated.
