### PR TITLE
Fix episode matching for packs using zero-padded episode numbers

### DIFF
--- a/piers/plugin.video.umbrella/resources/lib/modules/source_utils.py
+++ b/piers/plugin.video.umbrella/resources/lib/modules/source_utils.py
@@ -74,7 +74,7 @@ def seas_ep_filter(season, episode, release_title, split=False):
 
 		string1 = r'(s<<S>>[.-]?e[p]?[.-]?<<E>>[.-])'
 		string2 = r'(season[.-]?<<S>>[.-]?episode[.-]?<<E>>[.-])|' \
-						r'([s]?<<S>>[x.]<<E>>[.-])'
+						r'([s]?<<S>>[x.]0*<<E>>[.-])'
 		string3 = r'(s<<S>>e<<E1>>[.-]?e?<<E2>>[.-])'
 		string4 = r'([.-]<<S>>[.-]?<<E>>[.-])'
 		string5 = r'(episode[.-]?<<E>>[.-])'


### PR DESCRIPTION
## Issue

Umbrella fails to correctly match episodes from some packs that use more than two digits for the episode number.

For example, when requesting episode 2, Umbrella correctly generates the expected 1x02 pattern, but does not match filenames using:

```text
1x002
1x0002
```
As a result, episodes contained in these torrent packs may not be identified correctly, preventing Umbrella from selecting and playing the requested file.

## Fix

Updated the string2 episode-matching regex in seas_ep_filter() to allow optional leading zeros before the episode number:

```diff
- r'([s]?<<S>>[x.]<<E>>[.-])'
+ r'([s]?<<S>>[x.]0*<<E>>[.-])'
```
This preserves the existing matching behavior while additionally supporting episode formats such as:

* `1x02`
* `1x002`
* `1x0002`

The change only affects episode matching and does not alter the episode numbering generated by Umbrella.

## Testing

Verified that packs using the 1x002 naming convention are now correctly matched and the requested episodes can be selected and played.