### PR TITLE
fix: preserve Scrob Next Up order in Progress Episodes

### DIFF
--- a/matrix/plugin.video.umbrella/resources/lib/menus/episodes.py
+++ b/matrix/plugin.video.umbrella/resources/lib/menus/episodes.py
@@ -1630,15 +1630,9 @@ class Episodes:
 			except:
 				index = 0
 				page_limit = max(1, int(self.count) if self.count else 20)
+			# ReelDojo already returns Next Up in most-recently-watched order.
+			# scrob_progress_list restores that order after threaded enrichment.
 			self.list = cache.get(self.scrob_progress_list, 0, url, self.scrob_directProgressScrape)
-			self.sort(type='progress')
-			if self.list is None: self.list = []
-			prior_week = int(re.sub(r'[^0-9]', '', (self.date_time - timedelta(days=7)).strftime('%Y-%m-%d')))
-			sorted_list = []
-			top_items = [i for i in self.list if i.get('episode') == 1 and i.get('premiered') and (int(re.sub(r'[^0-9]', '', str(i['premiered']))) >= prior_week)]
-			sorted_list.extend(top_items)
-			sorted_list.extend([i for i in self.list if i not in top_items])
-			self.list = sorted_list
 			if self.list is None: self.list = []
 			self.list = [i for i in self.list if i.get('unaired', '') != 'true']
 			next_url = ''
@@ -1687,7 +1681,7 @@ class Episodes:
 			next_up = scrob.get_next_up()
 			if not next_up: return self.list
 			items = []
-			for item in next_up:
+			for position, item in enumerate(next_up):
 				try:
 					show = item.get('show') or item.get('series') or {}
 					next_episode = item.get('next_episode') or item.get('episode') or item.get('media') or {}
@@ -1704,7 +1698,8 @@ class Episodes:
 						or item.get('series_tvdb_id') or item.get('show_tvdb') or item.get('series_tvdb'))
 					items.append({'imdb': str(imdb_id or ''), 'tmdb': str(tmdb_id or ''), 'tvdb': str(tvdb_id or ''),
 						'season': int(season), 'episode': int(episode),
-						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or ''})
+						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or '',
+						'_scrob_position': position})
 				except: pass
 			if not items: return self.list
 
@@ -1745,6 +1740,7 @@ class Episodes:
 					values.update(showSeasons)
 					values.update(seasonEpisodes)
 					values.update(episode_meta)
+					values['_scrob_position'] = i['_scrob_position']
 					for k in ('episodes', 'snum', 'enum'): values.pop(k, None)
 					duration = values.get('duration')
 					if duration:
@@ -1793,6 +1789,8 @@ class Episodes:
 				batch = threads[i:i + _chunk]
 				[t.start() for t in batch]
 				[t.join() for t in batch]
+			self.list.sort(key=lambda item: item.get('_scrob_position', len(items)))
+			for item in self.list: item.pop('_scrob_position', None)
 		except:
 			from resources.lib.modules import log_utils
 			log_utils.error()

--- a/nexus/plugin.video.umbrella/resources/lib/menus/episodes.py
+++ b/nexus/plugin.video.umbrella/resources/lib/menus/episodes.py
@@ -1630,15 +1630,9 @@ class Episodes:
 			except:
 				index = 0
 				page_limit = max(1, int(self.count) if self.count else 20)
+			# ReelDojo already returns Next Up in most-recently-watched order.
+			# scrob_progress_list restores that order after threaded enrichment.
 			self.list = cache.get(self.scrob_progress_list, 0, url, self.scrob_directProgressScrape)
-			self.sort(type='progress')
-			if self.list is None: self.list = []
-			prior_week = int(re.sub(r'[^0-9]', '', (self.date_time - timedelta(days=7)).strftime('%Y-%m-%d')))
-			sorted_list = []
-			top_items = [i for i in self.list if i.get('episode') == 1 and i.get('premiered') and (int(re.sub(r'[^0-9]', '', str(i['premiered']))) >= prior_week)]
-			sorted_list.extend(top_items)
-			sorted_list.extend([i for i in self.list if i not in top_items])
-			self.list = sorted_list
 			if self.list is None: self.list = []
 			self.list = [i for i in self.list if i.get('unaired', '') != 'true']
 			next_url = ''
@@ -1687,7 +1681,7 @@ class Episodes:
 			next_up = scrob.get_next_up()
 			if not next_up: return self.list
 			items = []
-			for item in next_up:
+			for position, item in enumerate(next_up):
 				try:
 					show = item.get('show') or item.get('series') or {}
 					next_episode = item.get('next_episode') or item.get('episode') or item.get('media') or {}
@@ -1704,7 +1698,8 @@ class Episodes:
 						or item.get('series_tvdb_id') or item.get('show_tvdb') or item.get('series_tvdb'))
 					items.append({'imdb': str(imdb_id or ''), 'tmdb': str(tmdb_id or ''), 'tvdb': str(tvdb_id or ''),
 						'season': int(season), 'episode': int(episode),
-						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or ''})
+						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or '',
+						'_scrob_position': position})
 				except: pass
 			if not items: return self.list
 
@@ -1745,6 +1740,7 @@ class Episodes:
 					values.update(showSeasons)
 					values.update(seasonEpisodes)
 					values.update(episode_meta)
+					values['_scrob_position'] = i['_scrob_position']
 					for k in ('episodes', 'snum', 'enum'): values.pop(k, None)
 					duration = values.get('duration')
 					if duration:
@@ -1793,6 +1789,8 @@ class Episodes:
 				batch = threads[i:i + _chunk]
 				[t.start() for t in batch]
 				[t.join() for t in batch]
+			self.list.sort(key=lambda item: item.get('_scrob_position', len(items)))
+			for item in self.list: item.pop('_scrob_position', None)
 		except:
 			from resources.lib.modules import log_utils
 			log_utils.error()

--- a/omega/plugin.video.umbrella/resources/lib/menus/episodes.py
+++ b/omega/plugin.video.umbrella/resources/lib/menus/episodes.py
@@ -1630,15 +1630,9 @@ class Episodes:
 			except:
 				index = 0
 				page_limit = max(1, int(self.count) if self.count else 20)
+			# ReelDojo already returns Next Up in most-recently-watched order.
+			# scrob_progress_list restores that order after threaded enrichment.
 			self.list = cache.get(self.scrob_progress_list, 0, url, self.scrob_directProgressScrape)
-			self.sort(type='progress')
-			if self.list is None: self.list = []
-			prior_week = int(re.sub(r'[^0-9]', '', (self.date_time - timedelta(days=7)).strftime('%Y-%m-%d')))
-			sorted_list = []
-			top_items = [i for i in self.list if i.get('episode') == 1 and i.get('premiered') and (int(re.sub(r'[^0-9]', '', str(i['premiered']))) >= prior_week)]
-			sorted_list.extend(top_items)
-			sorted_list.extend([i for i in self.list if i not in top_items])
-			self.list = sorted_list
 			if self.list is None: self.list = []
 			self.list = [i for i in self.list if i.get('unaired', '') != 'true']
 			next_url = ''
@@ -1687,7 +1681,7 @@ class Episodes:
 			next_up = scrob.get_next_up()
 			if not next_up: return self.list
 			items = []
-			for item in next_up:
+			for position, item in enumerate(next_up):
 				try:
 					show = item.get('show') or item.get('series') or {}
 					next_episode = item.get('next_episode') or item.get('episode') or item.get('media') or {}
@@ -1704,7 +1698,8 @@ class Episodes:
 						or item.get('series_tvdb_id') or item.get('show_tvdb') or item.get('series_tvdb'))
 					items.append({'imdb': str(imdb_id or ''), 'tmdb': str(tmdb_id or ''), 'tvdb': str(tvdb_id or ''),
 						'season': int(season), 'episode': int(episode),
-						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or ''})
+						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or '',
+						'_scrob_position': position})
 				except: pass
 			if not items: return self.list
 
@@ -1745,6 +1740,7 @@ class Episodes:
 					values.update(showSeasons)
 					values.update(seasonEpisodes)
 					values.update(episode_meta)
+					values['_scrob_position'] = i['_scrob_position']
 					for k in ('episodes', 'snum', 'enum'): values.pop(k, None)
 					duration = values.get('duration')
 					if duration:
@@ -1793,6 +1789,8 @@ class Episodes:
 				batch = threads[i:i + _chunk]
 				[t.start() for t in batch]
 				[t.join() for t in batch]
+			self.list.sort(key=lambda item: item.get('_scrob_position', len(items)))
+			for item in self.list: item.pop('_scrob_position', None)
 		except:
 			from resources.lib.modules import log_utils
 			log_utils.error()

--- a/piers/plugin.video.umbrella/resources/lib/menus/episodes.py
+++ b/piers/plugin.video.umbrella/resources/lib/menus/episodes.py
@@ -1630,15 +1630,9 @@ class Episodes:
 			except:
 				index = 0
 				page_limit = max(1, int(self.count) if self.count else 20)
+			# ReelDojo already returns Next Up in most-recently-watched order.
+			# scrob_progress_list restores that order after threaded enrichment.
 			self.list = cache.get(self.scrob_progress_list, 0, url, self.scrob_directProgressScrape)
-			self.sort(type='progress')
-			if self.list is None: self.list = []
-			prior_week = int(re.sub(r'[^0-9]', '', (self.date_time - timedelta(days=7)).strftime('%Y-%m-%d')))
-			sorted_list = []
-			top_items = [i for i in self.list if i.get('episode') == 1 and i.get('premiered') and (int(re.sub(r'[^0-9]', '', str(i['premiered']))) >= prior_week)]
-			sorted_list.extend(top_items)
-			sorted_list.extend([i for i in self.list if i not in top_items])
-			self.list = sorted_list
 			if self.list is None: self.list = []
 			self.list = [i for i in self.list if i.get('unaired', '') != 'true']
 			next_url = ''
@@ -1687,7 +1681,7 @@ class Episodes:
 			next_up = scrob.get_next_up()
 			if not next_up: return self.list
 			items = []
-			for item in next_up:
+			for position, item in enumerate(next_up):
 				try:
 					show = item.get('show') or item.get('series') or {}
 					next_episode = item.get('next_episode') or item.get('episode') or item.get('media') or {}
@@ -1704,7 +1698,8 @@ class Episodes:
 						or item.get('series_tvdb_id') or item.get('show_tvdb') or item.get('series_tvdb'))
 					items.append({'imdb': str(imdb_id or ''), 'tmdb': str(tmdb_id or ''), 'tvdb': str(tvdb_id or ''),
 						'season': int(season), 'episode': int(episode),
-						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or ''})
+						'lastplayed': item.get('last_watched_at') or item.get('updated_at') or '',
+						'_scrob_position': position})
 				except: pass
 			if not items: return self.list
 
@@ -1745,6 +1740,7 @@ class Episodes:
 					values.update(showSeasons)
 					values.update(seasonEpisodes)
 					values.update(episode_meta)
+					values['_scrob_position'] = i['_scrob_position']
 					for k in ('episodes', 'snum', 'enum'): values.pop(k, None)
 					duration = values.get('duration')
 					if duration:
@@ -1793,6 +1789,8 @@ class Episodes:
 				batch = threads[i:i + _chunk]
 				[t.start() for t in batch]
 				[t.join() for t in batch]
+			self.list.sort(key=lambda item: item.get('_scrob_position', len(items)))
+			for item in self.list: item.pop('_scrob_position', None)
 		except:
 			from resources.lib.modules import log_utils
 			log_utils.error()


### PR DESCRIPTION
## Summary
- preserve ReelDojo/Scrob Next Up positions through threaded metadata enrichment
- stop the Scrob Progress Episodes folder from re-sorting and promoting recent premieres
- filter and paginate only after deterministic server ordering is restored
- retain the existing air-date sort for Upcoming Progress

## Validation
- verified the Shield's installed Umbrella 6.7.86 `episodes.py` matches this upstream revision
- `python3 -m py_compile` passes for Matrix, Omega, Nexus, and Piers package trees
- confirmed all four variants contain the same scoped change

This affects only Scrob Progress Episodes; Trakt, Simkl, MDBList, Floppy, Custom Trakt, and Upcoming Progress ordering are unchanged.